### PR TITLE
Moved echoing of output outside if statement

### DIFF
--- a/docker-args
+++ b/docker-args
@@ -6,6 +6,7 @@ APP="$1"
 PERSISTENT_FILE="PERSISTENT_STORAGE"
 PERSISTENT_FILE_PATH="$DOKKU_ROOT/$APP/$PERSISTENT_FILE"
 
+output=""
 if [[ -f "$PERSISTENT_FILE_PATH" ]]; then
   while read line           
   do           


### PR DESCRIPTION
Fixes the issue described in #5 where the `persistent-storage` plugin being called after other `docker-args` hooks, where the `persistent-storage` hook doesn't have a `PERSISTENT_STORAGE` file, ends up wiping the value of `docker-args` as generated by previous plugins.
