### PR TITLE
only mount docker volumes on deploy

### DIFF
--- a/docker-args
+++ b/docker-args
@@ -7,7 +7,7 @@ PERSISTENT_FILE="PERSISTENT_STORAGE"
 PERSISTENT_FILE_PATH="$DOKKU_ROOT/$APP/$PERSISTENT_FILE"
 
 output=""
-if [[ -f "$PERSISTENT_FILE_PATH" ]] && [[ "$PHASE" == "deploy" ]]; then
+if [[ -f "$PERSISTENT_FILE_PATH" ]] && [[ "$PHASE" != "build" ]]; then
   DONE=false
   until $DONE; do
     read line || DONE=true

--- a/docker-args
+++ b/docker-args
@@ -2,12 +2,12 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 STDIN=$(cat)
-APP="$1"
+APP="$1"; PHASE="$2"
 PERSISTENT_FILE="PERSISTENT_STORAGE"
 PERSISTENT_FILE_PATH="$DOKKU_ROOT/$APP/$PERSISTENT_FILE"
 
 output=""
-if [[ -f "$PERSISTENT_FILE_PATH" ]]; then
+if [[ -f "$PERSISTENT_FILE_PATH" ]] && [[ "$PHASE" == "deploy" ]]; then
   DONE=false
   until $DONE; do
     read line || DONE=true


### PR DESCRIPTION
Apologies for the other PR. Accidentally opened from my master branch.

A few days ago dokku added running `dokku-args` plugins for the `build` phase. This seems to have caused an issue with (at least) heroku-buildpack-python. (ref: progrium/dokku#906)

Additionally, `dokku` now calls `docker-args` plugins with a build phase passed as an argument. See: https://github.com/progrium/dokku/blob/fb3492c8242521dec4ed8428983ea752db710f86/dokku#L87

This patch will only mount volumes if we get the deploy call. This is tested in my previously broken environments.

This seems to also cause an issue later on in the pipeline with `/build/builder`:
https://github.com/progrium/buildstep/blob/091eafdad7ccf5f4584aa21704397fd1dc1fd208/builder/builder#L70
